### PR TITLE
feat: enhance error messages for missing non-HF datasets

### DIFF
--- a/cuvisai_examples/configs/dataset/efficientad.yaml
+++ b/cuvisai_examples/configs/dataset/efficientad.yaml
@@ -13,9 +13,14 @@ train:
     mean: [0.0267, 0.0267, 0.0267, 0.0267, 0.0267, 0.0267]
     std:  [0.0137, 0.0137, 0.0137, 0.0137, 0.0137, 0.0137]
     obtain:
+      # For HF datasets (current default)
       hf:
         repo_id: nghorbani/Hyperspektral-Small
         local_dir: data/Hyperspektral-Small
+      # For manual downloads (example - uncomment and modify as needed) (important-comment)
+      # manual:
+      #   url: "https://www.dropbox.com/scl/fi/example/data.zip" (important-comment)
+      #   instructions: "Download and extract the dataset using: curl -L 'URL' -o data.zip && unzip -q data.zip -d ./data" (important-comment)
 
 val:
   type: "EfficientADCuvisDataSet"
@@ -32,9 +37,14 @@ val:
     mean: [0.0267, 0.0267, 0.0267, 0.0267, 0.0267, 0.0267]
     std:  [0.0137, 0.0137, 0.0137, 0.0137, 0.0137, 0.0137]
     obtain:
+      # For HF datasets (current default)
       hf:
         repo_id: nghorbani/Hyperspektral-Small
         local_dir: data/Hyperspektral-Small
+      # For manual downloads (example - uncomment and modify as needed)
+      # manual:
+      #   url: "https://www.dropbox.com/scl/fi/example/data.zip"
+      #   instructions: "Download and extract the dataset using: curl -L 'URL' -o data.zip && unzip -q data.zip -d ./data"
 
 test:
   type: "EfficientADCuvisDataSet"
@@ -51,6 +61,11 @@ test:
     mean: [0.0267, 0.0267, 0.0267, 0.0267, 0.0267, 0.0267]
     std:  [0.0137, 0.0137, 0.0137, 0.0137, 0.0137, 0.0137]
     obtain:
+      # For HF datasets (current default)
       hf:
         repo_id: nghorbani/Hyperspektral-Small
         local_dir: data/Hyperspektral-Small
+      # For manual downloads (example - uncomment and modify as needed)
+      # manual:
+      #   url: "https://www.dropbox.com/scl/fi/example/data.zip"
+      #   instructions: "Download and extract the dataset using: curl -L 'URL' -o data.zip && unzip -q data.zip -d ./data"

--- a/cuvisai_examples/datasets/efficientad_dataset.py
+++ b/cuvisai_examples/datasets/efficientad_dataset.py
@@ -73,10 +73,25 @@ class EfficientADCuvisDataSet(Dataset):
                     logging.getLogger(__name__).warning(
                         "Dataset dir missing and obtain.hf provided but repo_id or HF_TOKEN missing; skipping download."
                     )
-            else:
-                logging.getLogger(__name__).warning(
-                    f"Dataset dir not found: {self.dataset_dir}"
+            elif obtain and isinstance(obtain, dict) and "manual" in obtain:
+                manual = obtain.get("manual") or {}
+                download_url = manual.get("url")
+                instructions = manual.get("instructions", "Please download the dataset manually")
+                logging.getLogger(__name__).error(
+                    f"Dataset not found at: {self.dataset_dir}\n"
+                    f"{instructions}\n"
+                    f"Expected location: {os.path.abspath(self.dataset_dir)}\n"
+                    f"After downloading, run this script once more."
+                    + (f"\nDownload URL: {download_url}" if download_url else "")
                 )
+                raise FileNotFoundError(f"Dataset directory not found: {self.dataset_dir}")
+            else:
+                logging.getLogger(__name__).error(
+                    f"Dataset not found at: {self.dataset_dir}\n"
+                    f"Please download the dataset to: {os.path.abspath(self.dataset_dir)}\n"
+                    f"After downloading, run this script once more."
+                )
+                raise FileNotFoundError(f"Dataset directory not found: {self.dataset_dir}")
 
         self.npz_paths = [
             os.path.join(root, f)

--- a/cuvisai_examples/datasets/perpixel_ae_dataset.py
+++ b/cuvisai_examples/datasets/perpixel_ae_dataset.py
@@ -66,10 +66,25 @@ class PerPixelAECuvisDataSet(Dataset):
                     logging.getLogger(__name__).warning(
                         "Dataset dir missing and obtain.hf provided but repo_id or HF_TOKEN missing; skipping download."
                     )
-            else:
-                logging.getLogger(__name__).warning(
-                    f"Dataset dir not found: {self.path}"
+            elif obtain and isinstance(obtain, dict) and "manual" in obtain:
+                manual = obtain.get("manual") or {}
+                download_url = manual.get("url")
+                instructions = manual.get("instructions", "Please download the dataset manually")
+                logging.getLogger(__name__).error(
+                    f"Dataset not found at: {self.path}\n"
+                    f"{instructions}\n"
+                    f"Expected location: {os.path.abspath(self.path)}\n"
+                    f"After downloading, run this script once more."
+                    + (f"\nDownload URL: {download_url}" if download_url else "")
                 )
+                raise FileNotFoundError(f"Dataset directory not found: {self.path}")
+            else:
+                logging.getLogger(__name__).error(
+                    f"Dataset not found at: {self.path}\n"
+                    f"Please download the dataset to: {os.path.abspath(self.path)}\n"
+                    f"After downloading, run this script once more."
+                )
+                raise FileNotFoundError(f"Dataset directory not found: {self.path}")
 
         self.file_paths = [
             os.path.join(root, f)

--- a/cuvisai_examples/datasets/strawberry_dataset.py
+++ b/cuvisai_examples/datasets/strawberry_dataset.py
@@ -69,8 +69,25 @@ class StrawberryDataset(Dataset):
                     print(
                         "Dataset dir missing and obtain.hf provided but repo_id or HF_TOKEN missing; skipping download."
                     )
+            elif obtain and isinstance(obtain, dict) and "manual" in obtain:
+                manual = obtain.get("manual") or {}
+                download_url = manual.get("url")
+                instructions = manual.get("instructions", "Please download the dataset manually")
+                print(
+                    f"Dataset not found at: {self.root_dir}\n"
+                    f"{instructions}\n"
+                    f"Expected location: {self.root_dir.resolve()}\n"
+                    f"After downloading, run this script once more."
+                    + (f"\nDownload URL: {download_url}" if download_url else "")
+                )
+                raise FileNotFoundError(f"Dataset directory not found: {self.root_dir}")
             else:
-                print(f"Dataset dir not found: {self.root_dir}")
+                print(
+                    f"Dataset not found at: {self.root_dir}\n"
+                    f"Please download the dataset to: {self.root_dir.resolve()}\n"
+                    f"After downloading, run this script once more."
+                )
+                raise FileNotFoundError(f"Dataset directory not found: {self.root_dir}")
 
         self.file_paths: List[Path] = []
         for path in self.root_dir.glob("*.cu3s"):


### PR DESCRIPTION
# feat: enhance error messages for missing non-HF datasets

## Summary

This PR improves the dataset download mechanism by providing helpful error messages when datasets are missing and cannot be automatically downloaded from Hugging Face. Previously, the system would silently log warnings and continue, potentially causing confusing failures later. Now it provides clear instructions on where to download datasets manually and suggests running the script again.

**Key Changes:**
- Added support for `obtain.manual` configuration with `url` and `instructions` fields
- Enhanced error messages to show absolute paths and clear download instructions  
- Changed behavior from logging warnings to raising `FileNotFoundError` for missing datasets
- Updated EfficientAD config with example manual download configuration (commented)
- Applied changes consistently across all three dataset classes: `EfficientADCuvisDataSet`, `PerPixelAECuvisDataSet`, and `StrawberryDataset`

## Review & Testing Checklist for Human

**⚠️ BREAKING CHANGE WARNING**: This PR changes behavior from logging warnings to raising exceptions when datasets are missing.

- [ ] **Test existing workflows still work**: Verify that training with missing datasets that should auto-download from HF still works correctly
- [ ] **Test enhanced error messages**: Remove a dataset directory and run training to confirm the new error messages are helpful and correctly formatted
- [ ] **Verify no regression in HF auto-download**: Confirm that the existing Hugging Face dataset download functionality wasn't broken
- [ ] **Review config file changes**: Check that the commented manual download examples in `efficientad.yaml` are clear and won't cause confusion

### Test Plan Recommendation
1. Run `uv run cuvisai-train model=efficientad/medium dataset=efficientad trainer.max_epochs=1` with missing dataset to see enhanced error messages
2. Test with HF_TOKEN configured to verify auto-download still works
3. Try creating a custom config with `obtain.manual` section to test the new functionality

### Notes
- The error handling approach differs between dataset classes (logging vs print), but this maintains existing patterns
- All lint checks passed
- Tested manual download error message formatting and it displays correctly with absolute paths and clear instructions

**Link to Devin run**: https://app.devin.ai/sessions/e0a052e52f004c2f8c3f358662bb2ea3  
**Requested by**: Nima Ghorbani (@nghorbani)