### PR TITLE
feat: set HyperspectralTiny as default dataset for faster testing

### DIFF
--- a/cuvisai_examples/configs/dataset/efficientad.yaml
+++ b/cuvisai_examples/configs/dataset/efficientad.yaml
@@ -14,7 +14,7 @@ train:
     std:  [0.0137, 0.0137, 0.0137, 0.0137, 0.0137, 0.0137]
     obtain:
       hf:
-        repo_id: nghorbani/Hyperspektral-Small
+        repo_id: nghorbani/HyperspectralTiny
         local_dir: data/Hyperspektral-Small
 
 val:
@@ -33,7 +33,7 @@ val:
     std:  [0.0137, 0.0137, 0.0137, 0.0137, 0.0137, 0.0137]
     obtain:
       hf:
-        repo_id: nghorbani/Hyperspektral-Small
+        repo_id: nghorbani/HyperspectralTiny
         local_dir: data/Hyperspektral-Small
 
 test:
@@ -52,5 +52,5 @@ test:
     std:  [0.0137, 0.0137, 0.0137, 0.0137, 0.0137, 0.0137]
     obtain:
       hf:
-        repo_id: nghorbani/Hyperspektral-Small
+        repo_id: nghorbani/HyperspectralTiny
         local_dir: data/Hyperspektral-Small

--- a/cuvisai_examples/configs/dataset/perpixel_ae.yaml
+++ b/cuvisai_examples/configs/dataset/perpixel_ae.yaml
@@ -2,7 +2,7 @@
 train:
   type: PerPixelAECuvisDataSet
   params:
-    dataset_dir: data/cubes
+    dataset_dir: data/Hyperspektral-Small
     mode: train
     max_img_shape: 1500
     channels: ALL
@@ -12,13 +12,13 @@ train:
     std: null
     obtain:
       hf:
-        repo_id: nghorbani/Hyperspektral-Small
+        repo_id: nghorbani/HyperspectralTiny
         local_dir: data/Hyperspektral-Small
 
 val:
   type: PerPixelAECuvisDataSet
   params:
-    dataset_dir: data/cubes
+    dataset_dir: data/Hyperspektral-Small
     mode: test
     max_img_shape: 1500
     channels: ALL
@@ -28,13 +28,13 @@ val:
     std: null
     obtain:
       hf:
-        repo_id: nghorbani/Hyperspektral-Small
+        repo_id: nghorbani/HyperspectralTiny
         local_dir: data/Hyperspektral-Small
 
 test:
   type: PerPixelAECuvisDataSet
   params:
-    dataset_dir: data/cubes
+    dataset_dir: data/Hyperspektral-Small
     mode: test
     max_img_shape: 1500
     channels: ALL
@@ -44,5 +44,5 @@ test:
     std: null
     obtain:
       hf:
-        repo_id: nghorbani/Hyperspektral-Small
+        repo_id: nghorbani/HyperspectralTiny
         local_dir: data/Hyperspektral-Small


### PR DESCRIPTION
# feat: set HyperspectralTiny as default dataset for faster testing

## Summary
Updates default HuggingFace dataset from `nghorbani/Hyperspektral-Small` to `nghorbani/HyperspectralTiny` for both EfficientAD and PerPixelAE configurations. This provides much faster dataset downloads (56 files vs 13k+ files) enabling quicker testing and development iterations.

**Key changes:**
- EfficientAD: Updated `repo_id` to use HyperspectralTiny across train/val/test splits
- PerPixelAE: Updated `repo_id` and fixed `dataset_dir` path mismatch (`data/cubes` → `data/Hyperspektral-Small`) to align with HF download location

## Review & Testing Checklist for Human
- [ ] **Verify dataset compatibility**: Confirm HyperspectralTiny contains the same data structure and format as Hyperspektral-Small
- [ ] **Test EfficientAD training**: Run `uv run cuvisai-train model=efficientad/medium dataset=efficientad trainer.max_epochs=1` and verify it downloads and trains successfully  
- [ ] **Test PerPixelAE training**: Run `uv run cuvisai-train model=perpixel_ae dataset=perpixel_ae trainer.max_epochs=1` and verify dataset loads correctly (previous version showed empty dataset warnings)

### Notes
- The PerPixelAE `dataset_dir` change fixes a path mismatch where the config pointed to `data/cubes` but HF downloads to `data/Hyperspektral-Small`
- Mean/std normalization parameters remain unchanged - verify these are still appropriate for the smaller dataset
- Link to Devin run: https://app.devin.ai/sessions/e0a052e52f004c2f8c3f358662bb2ea3
- Requested by: @nghorbani