### PR TITLE
feat: add dataset variants with variant parameter

### DIFF
--- a/cuvisai_examples/configs/dataset/efficientad.yaml
+++ b/cuvisai_examples/configs/dataset/efficientad.yaml
@@ -1,6 +1,7 @@
 train:
   type: "EfficientADCuvisDataSet"
   params:
+    variant: "tiny"
     dataset_dir: ./data/Hyperspektral-Small/bedding_dataset
     mode: "train"
     imagenet_dir: ./data/ImageNet_6_channel
@@ -12,14 +13,11 @@ train:
     channels: "ALL"
     mean: [0.0267, 0.0267, 0.0267, 0.0267, 0.0267, 0.0267]
     std:  [0.0137, 0.0137, 0.0137, 0.0137, 0.0137, 0.0137]
-    obtain:
-      hf:
-        repo_id: nghorbani/Hyperspektral-Small
-        local_dir: data/Hyperspektral-Small
 
 val:
   type: "EfficientADCuvisDataSet"
   params:
+    variant: "tiny"
     dataset_dir: ./data/Hyperspektral-Small/bedding_dataset
     mode: "test"
     imagenet_dir: ./data/ImageNet_6_channel
@@ -31,14 +29,11 @@ val:
     channels: "ALL"
     mean: [0.0267, 0.0267, 0.0267, 0.0267, 0.0267, 0.0267]
     std:  [0.0137, 0.0137, 0.0137, 0.0137, 0.0137, 0.0137]
-    obtain:
-      hf:
-        repo_id: nghorbani/Hyperspektral-Small
-        local_dir: data/Hyperspektral-Small
 
 test:
   type: "EfficientADCuvisDataSet"
   params:
+    variant: "tiny"
     dataset_dir: ./data/Hyperspektral-Small/bedding_dataset
     mode: "test"
     imagenet_dir: ./data/ImageNet_6_channel
@@ -50,7 +45,3 @@ test:
     channels: "ALL"
     mean: [0.0267, 0.0267, 0.0267, 0.0267, 0.0267, 0.0267]
     std:  [0.0137, 0.0137, 0.0137, 0.0137, 0.0137, 0.0137]
-    obtain:
-      hf:
-        repo_id: nghorbani/Hyperspektral-Small
-        local_dir: data/Hyperspektral-Small

--- a/cuvisai_examples/configs/dataset/efficientad.yaml
+++ b/cuvisai_examples/configs/dataset/efficientad.yaml
@@ -1,7 +1,6 @@
 train:
   type: "EfficientADCuvisDataSet"
   params:
-    variant: "tiny"
     dataset_dir: ./data/Hyperspektral-Small/bedding_dataset
     mode: "train"
     imagenet_dir: ./data/ImageNet_6_channel
@@ -13,11 +12,14 @@ train:
     channels: "ALL"
     mean: [0.0267, 0.0267, 0.0267, 0.0267, 0.0267, 0.0267]
     std:  [0.0137, 0.0137, 0.0137, 0.0137, 0.0137, 0.0137]
+    obtain:
+      hf:
+        repo_id: nghorbani/Hyperspektral-Small
+        local_dir: data/Hyperspektral-Small
 
 val:
   type: "EfficientADCuvisDataSet"
   params:
-    variant: "tiny"
     dataset_dir: ./data/Hyperspektral-Small/bedding_dataset
     mode: "test"
     imagenet_dir: ./data/ImageNet_6_channel
@@ -29,11 +31,14 @@ val:
     channels: "ALL"
     mean: [0.0267, 0.0267, 0.0267, 0.0267, 0.0267, 0.0267]
     std:  [0.0137, 0.0137, 0.0137, 0.0137, 0.0137, 0.0137]
+    obtain:
+      hf:
+        repo_id: nghorbani/Hyperspektral-Small
+        local_dir: data/Hyperspektral-Small
 
 test:
   type: "EfficientADCuvisDataSet"
   params:
-    variant: "tiny"
     dataset_dir: ./data/Hyperspektral-Small/bedding_dataset
     mode: "test"
     imagenet_dir: ./data/ImageNet_6_channel
@@ -45,3 +50,7 @@ test:
     channels: "ALL"
     mean: [0.0267, 0.0267, 0.0267, 0.0267, 0.0267, 0.0267]
     std:  [0.0137, 0.0137, 0.0137, 0.0137, 0.0137, 0.0137]
+    obtain:
+      hf:
+        repo_id: nghorbani/Hyperspektral-Small
+        local_dir: data/Hyperspektral-Small

--- a/cuvisai_examples/configs/dataset/efficientad.yaml
+++ b/cuvisai_examples/configs/dataset/efficientad.yaml
@@ -1,7 +1,7 @@
 train:
   type: "EfficientADCuvisDataSet"
   params:
-    dataset_dir: ./data/Hyperspektral-Small/bedding_dataset
+    dataset_dir: ./data/HyperspectralTiny/bedding_dataset
     mode: "train"
     imagenet_dir: ./data/ImageNet_6_channel
     imagenet_file_ending: ".npy"
@@ -14,13 +14,13 @@ train:
     std:  [0.0137, 0.0137, 0.0137, 0.0137, 0.0137, 0.0137]
     obtain:
       hf:
-        repo_id: nghorbani/Hyperspektral-Small
-        local_dir: data/Hyperspektral-Small
+        repo_id: nghorbani/HyperspectralTiny
+        local_dir: data/HyperspectralTiny
 
 val:
   type: "EfficientADCuvisDataSet"
   params:
-    dataset_dir: ./data/Hyperspektral-Small/bedding_dataset
+    dataset_dir: ./data/HyperspectralTiny/bedding_dataset
     mode: "test"
     imagenet_dir: ./data/ImageNet_6_channel
     imagenet_file_ending: ".npy"
@@ -33,13 +33,13 @@ val:
     std:  [0.0137, 0.0137, 0.0137, 0.0137, 0.0137, 0.0137]
     obtain:
       hf:
-        repo_id: nghorbani/Hyperspektral-Small
-        local_dir: data/Hyperspektral-Small
+        repo_id: nghorbani/HyperspectralTiny
+        local_dir: data/HyperspectralTiny
 
 test:
   type: "EfficientADCuvisDataSet"
   params:
-    dataset_dir: ./data/Hyperspektral-Small/bedding_dataset
+    dataset_dir: ./data/HyperspectralTiny/bedding_dataset
     mode: "test"
     imagenet_dir: ./data/ImageNet_6_channel
     imagenet_file_ending: ".npy"
@@ -52,5 +52,5 @@ test:
     std:  [0.0137, 0.0137, 0.0137, 0.0137, 0.0137, 0.0137]
     obtain:
       hf:
-        repo_id: nghorbani/Hyperspektral-Small
-        local_dir: data/Hyperspektral-Small
+        repo_id: nghorbani/HyperspectralTiny
+        local_dir: data/HyperspectralTiny

--- a/cuvisai_examples/configs/dataset/perpixel_ae.yaml
+++ b/cuvisai_examples/configs/dataset/perpixel_ae.yaml
@@ -2,6 +2,7 @@
 train:
   type: PerPixelAECuvisDataSet
   params:
+    variant: "tiny"
     dataset_dir: data/cubes
     mode: train
     max_img_shape: 1500
@@ -10,14 +11,11 @@ train:
     normalize: true
     mean: null
     std: null
-    obtain:
-      hf:
-        repo_id: nghorbani/Hyperspektral-Small
-        local_dir: data/Hyperspektral-Small
 
 val:
   type: PerPixelAECuvisDataSet
   params:
+    variant: "tiny"
     dataset_dir: data/cubes
     mode: test
     max_img_shape: 1500
@@ -26,14 +24,11 @@ val:
     normalize: true
     mean: null
     std: null
-    obtain:
-      hf:
-        repo_id: nghorbani/Hyperspektral-Small
-        local_dir: data/Hyperspektral-Small
 
 test:
   type: PerPixelAECuvisDataSet
   params:
+    variant: "tiny"
     dataset_dir: data/cubes
     mode: test
     max_img_shape: 1500
@@ -42,7 +37,3 @@ test:
     normalize: true
     mean: null
     std: null
-    obtain:
-      hf:
-        repo_id: nghorbani/Hyperspektral-Small
-        local_dir: data/Hyperspektral-Small

--- a/cuvisai_examples/configs/dataset/perpixel_ae.yaml
+++ b/cuvisai_examples/configs/dataset/perpixel_ae.yaml
@@ -2,7 +2,6 @@
 train:
   type: PerPixelAECuvisDataSet
   params:
-    variant: "tiny"
     dataset_dir: data/cubes
     mode: train
     max_img_shape: 1500
@@ -11,11 +10,14 @@ train:
     normalize: true
     mean: null
     std: null
+    obtain:
+      hf:
+        repo_id: nghorbani/Hyperspektral-Small
+        local_dir: data/Hyperspektral-Small
 
 val:
   type: PerPixelAECuvisDataSet
   params:
-    variant: "tiny"
     dataset_dir: data/cubes
     mode: test
     max_img_shape: 1500
@@ -24,11 +26,14 @@ val:
     normalize: true
     mean: null
     std: null
+    obtain:
+      hf:
+        repo_id: nghorbani/Hyperspektral-Small
+        local_dir: data/Hyperspektral-Small
 
 test:
   type: PerPixelAECuvisDataSet
   params:
-    variant: "tiny"
     dataset_dir: data/cubes
     mode: test
     max_img_shape: 1500
@@ -37,3 +42,7 @@ test:
     normalize: true
     mean: null
     std: null
+    obtain:
+      hf:
+        repo_id: nghorbani/Hyperspektral-Small
+        local_dir: data/Hyperspektral-Small

--- a/cuvisai_examples/configs/dataset/perpixel_ae.yaml
+++ b/cuvisai_examples/configs/dataset/perpixel_ae.yaml
@@ -12,8 +12,8 @@ train:
     std: null
     obtain:
       hf:
-        repo_id: nghorbani/Hyperspektral-Small
-        local_dir: data/Hyperspektral-Small
+        repo_id: nghorbani/HyperspectralTiny
+        local_dir: data/HyperspectralTiny
 
 val:
   type: PerPixelAECuvisDataSet
@@ -28,8 +28,8 @@ val:
     std: null
     obtain:
       hf:
-        repo_id: nghorbani/Hyperspektral-Small
-        local_dir: data/Hyperspektral-Small
+        repo_id: nghorbani/HyperspectralTiny
+        local_dir: data/HyperspectralTiny
 
 test:
   type: PerPixelAECuvisDataSet
@@ -44,5 +44,5 @@ test:
     std: null
     obtain:
       hf:
-        repo_id: nghorbani/Hyperspektral-Small
-        local_dir: data/Hyperspektral-Small
+        repo_id: nghorbani/HyperspectralTiny
+        local_dir: data/HyperspectralTiny

--- a/cuvisai_examples/datasets/efficientad_dataset.py
+++ b/cuvisai_examples/datasets/efficientad_dataset.py
@@ -21,13 +21,6 @@ except Exception:
 
 @DATASETS.register("EfficientADCuvisDataSet")
 class EfficientADCuvisDataSet(Dataset):
-    VARIANT_REPOS = {
-        "tiny": "nghorbani/HyperspectralTiny",
-        "small": "nghorbani/Hyperspektral-Small",
-        "medium": "nghorbani/HyperspectralMedium",
-        "large": "nghorbani/HyperspectralLarge",
-    }
-    
     def __init__(
         self,
         dataset_dir: str = "data/cubes",
@@ -41,19 +34,8 @@ class EfficientADCuvisDataSet(Dataset):
         max_img_shape: int = 1500,
         white_percentage: float = 0.55,
         channels: str = "ALL",
-        variant: Optional[str] = None,
         obtain: Optional[dict] = None,
     ):
-        if variant and variant in self.VARIANT_REPOS:
-            if not obtain:
-                obtain = {}
-            if "hf" not in obtain:
-                obtain["hf"] = {}
-            if "repo_id" not in obtain["hf"]:
-                obtain["hf"]["repo_id"] = self.VARIANT_REPOS[variant]
-            if "local_dir" not in obtain["hf"]:
-                obtain["hf"]["local_dir"] = f"data/{variant}_dataset"
-        
         self.dataset_dir = dataset_dir
         self.mode = mode
         self.imagenet_file_ending = imagenet_file_ending
@@ -65,7 +47,6 @@ class EfficientADCuvisDataSet(Dataset):
         self.normalize = normalize
         self.white_percentage = white_percentage
         self.channels = channels
-        self.variant = variant
         if not os.path.isdir(self.dataset_dir):
             if obtain and isinstance(obtain, dict) and "hf" in obtain:
                 hf = obtain.get("hf") or {}
@@ -149,7 +130,6 @@ class EfficientADCuvisDataSet(Dataset):
 
         logging.getLogger(__name__).info(
             f"EfficientAD dataset init: mode={self.mode} dir={os.path.abspath(self.dataset_dir)}"
-            + (f" variant={self.variant}" if self.variant else "")
         )
         logging.getLogger(__name__).info(f"Found {len(self.npz_paths)} NPZ files")
         if not self.uses_npz:

--- a/cuvisai_examples/datasets/efficientad_dataset.py
+++ b/cuvisai_examples/datasets/efficientad_dataset.py
@@ -21,6 +21,13 @@ except Exception:
 
 @DATASETS.register("EfficientADCuvisDataSet")
 class EfficientADCuvisDataSet(Dataset):
+    VARIANT_REPOS = {
+        "tiny": "nghorbani/HyperspectralTiny",
+        "small": "nghorbani/Hyperspektral-Small",
+        "medium": "nghorbani/HyperspectralMedium",
+        "large": "nghorbani/HyperspectralLarge",
+    }
+    
     def __init__(
         self,
         dataset_dir: str = "data/cubes",
@@ -34,8 +41,19 @@ class EfficientADCuvisDataSet(Dataset):
         max_img_shape: int = 1500,
         white_percentage: float = 0.55,
         channels: str = "ALL",
+        variant: Optional[str] = None,
         obtain: Optional[dict] = None,
     ):
+        if variant and variant in self.VARIANT_REPOS:
+            if not obtain:
+                obtain = {}
+            if "hf" not in obtain:
+                obtain["hf"] = {}
+            if "repo_id" not in obtain["hf"]:
+                obtain["hf"]["repo_id"] = self.VARIANT_REPOS[variant]
+            if "local_dir" not in obtain["hf"]:
+                obtain["hf"]["local_dir"] = f"data/{variant}_dataset"
+        
         self.dataset_dir = dataset_dir
         self.mode = mode
         self.imagenet_file_ending = imagenet_file_ending
@@ -47,6 +65,7 @@ class EfficientADCuvisDataSet(Dataset):
         self.normalize = normalize
         self.white_percentage = white_percentage
         self.channels = channels
+        self.variant = variant
         if not os.path.isdir(self.dataset_dir):
             if obtain and isinstance(obtain, dict) and "hf" in obtain:
                 hf = obtain.get("hf") or {}
@@ -130,6 +149,7 @@ class EfficientADCuvisDataSet(Dataset):
 
         logging.getLogger(__name__).info(
             f"EfficientAD dataset init: mode={self.mode} dir={os.path.abspath(self.dataset_dir)}"
+            + (f" variant={self.variant}" if self.variant else "")
         )
         logging.getLogger(__name__).info(f"Found {len(self.npz_paths)} NPZ files")
         if not self.uses_npz:

--- a/cuvisai_examples/datasets/perpixel_ae_dataset.py
+++ b/cuvisai_examples/datasets/perpixel_ae_dataset.py
@@ -17,12 +17,6 @@ except Exception:
 
 @DATASETS.register("PerPixelAECuvisDataSet")
 class PerPixelAECuvisDataSet(Dataset):
-    VARIANT_REPOS = {
-        "tiny": "nghorbani/HyperspectralTiny",
-        "small": "nghorbani/Hyperspektral-Small",
-        "medium": "nghorbani/HyperspectralMedium",
-        "large": "nghorbani/HyperspectralLarge",
-    }
     
     def __init__(
         self,
@@ -34,19 +28,9 @@ class PerPixelAECuvisDataSet(Dataset):
         normalize: bool = True,
         mean: Optional[List[float]] = None,
         std: Optional[List[float]] = None,
-        variant: Optional[str] = None,
         obtain: Optional[dict] = None,
         path: Optional[str] = None,
     ):
-        if variant and variant in self.VARIANT_REPOS:
-            if not obtain:
-                obtain = {}
-            if "hf" not in obtain:
-                obtain["hf"] = {}
-            if "repo_id" not in obtain["hf"]:
-                obtain["hf"]["repo_id"] = self.VARIANT_REPOS[variant]
-            if "local_dir" not in obtain["hf"]:
-                obtain["hf"]["local_dir"] = f"data/{variant}_dataset"
         
         if path and not dataset_dir:
             dataset_dir = path
@@ -58,7 +42,6 @@ class PerPixelAECuvisDataSet(Dataset):
         self.normalize = normalize
         self.mean = mean
         self.std = std
-        self.variant = variant
         if not os.path.isdir(self.path):
             if obtain and isinstance(obtain, dict) and "hf" in obtain:
                 hf = obtain.get("hf") or {}

--- a/cuvisai_examples/datasets/perpixel_ae_dataset.py
+++ b/cuvisai_examples/datasets/perpixel_ae_dataset.py
@@ -17,6 +17,13 @@ except Exception:
 
 @DATASETS.register("PerPixelAECuvisDataSet")
 class PerPixelAECuvisDataSet(Dataset):
+    VARIANT_REPOS = {
+        "tiny": "nghorbani/HyperspectralTiny",
+        "small": "nghorbani/Hyperspektral-Small",
+        "medium": "nghorbani/HyperspectralMedium",
+        "large": "nghorbani/HyperspectralLarge",
+    }
+    
     def __init__(
         self,
         dataset_dir: str = "data/cubes",
@@ -27,9 +34,20 @@ class PerPixelAECuvisDataSet(Dataset):
         normalize: bool = True,
         mean: Optional[List[float]] = None,
         std: Optional[List[float]] = None,
+        variant: Optional[str] = None,
         obtain: Optional[dict] = None,
         path: Optional[str] = None,
     ):
+        if variant and variant in self.VARIANT_REPOS:
+            if not obtain:
+                obtain = {}
+            if "hf" not in obtain:
+                obtain["hf"] = {}
+            if "repo_id" not in obtain["hf"]:
+                obtain["hf"]["repo_id"] = self.VARIANT_REPOS[variant]
+            if "local_dir" not in obtain["hf"]:
+                obtain["hf"]["local_dir"] = f"data/{variant}_dataset"
+        
         if path and not dataset_dir:
             dataset_dir = path
         self.path = dataset_dir
@@ -40,6 +58,7 @@ class PerPixelAECuvisDataSet(Dataset):
         self.normalize = normalize
         self.mean = mean
         self.std = std
+        self.variant = variant
         if not os.path.isdir(self.path):
             if obtain and isinstance(obtain, dict) and "hf" in obtain:
                 hf = obtain.get("hf") or {}

--- a/cuvisai_examples/datasets/strawberry_dataset.py
+++ b/cuvisai_examples/datasets/strawberry_dataset.py
@@ -17,6 +17,13 @@ except Exception:
 
 @DATASETS.register("StrawberryDataset")
 class StrawberryDataset(Dataset):
+    VARIANT_REPOS = {
+        "tiny": "nghorbani/HyperspectralTiny",
+        "small": "nghorbani/Hyperspektral-Small",
+        "medium": "nghorbani/HyperspectralMedium",
+        "large": "nghorbani/HyperspectralLarge",
+    }
+    
     def __init__(
         self,
         root_dir: str,
@@ -30,6 +37,7 @@ class StrawberryDataset(Dataset):
         strawberry_range: Tuple[int, int] = (0, 220),
         sides_to_exclude: Optional[List[int]] = None,
         days_to_exclude: Optional[List[int]] = None,
+        variant: Optional[str] = None,
         obtain: Optional[dict] = None,
     ):
         if days_to_exclude is None:
@@ -41,7 +49,18 @@ class StrawberryDataset(Dataset):
         if cube_size is None:
             cube_size = [200, 200]
 
+        if variant and variant in self.VARIANT_REPOS:
+            if not obtain:
+                obtain = {}
+            if "hf" not in obtain:
+                obtain["hf"] = {}
+            if "repo_id" not in obtain["hf"]:
+                obtain["hf"]["repo_id"] = self.VARIANT_REPOS[variant]
+            if "local_dir" not in obtain["hf"]:
+                obtain["hf"]["local_dir"] = f"data/{variant}_dataset"
+
         self.root_dir = Path(root_dir)
+        self.variant = variant
 
         if not self.root_dir.exists():
             if obtain and isinstance(obtain, dict) and "hf" in obtain:

--- a/cuvisai_examples/datasets/strawberry_dataset.py
+++ b/cuvisai_examples/datasets/strawberry_dataset.py
@@ -17,12 +17,6 @@ except Exception:
 
 @DATASETS.register("StrawberryDataset")
 class StrawberryDataset(Dataset):
-    VARIANT_REPOS = {
-        "tiny": "nghorbani/HyperspectralTiny",
-        "small": "nghorbani/Hyperspektral-Small",
-        "medium": "nghorbani/HyperspectralMedium",
-        "large": "nghorbani/HyperspectralLarge",
-    }
     
     def __init__(
         self,
@@ -37,7 +31,6 @@ class StrawberryDataset(Dataset):
         strawberry_range: Tuple[int, int] = (0, 220),
         sides_to_exclude: Optional[List[int]] = None,
         days_to_exclude: Optional[List[int]] = None,
-        variant: Optional[str] = None,
         obtain: Optional[dict] = None,
     ):
         if days_to_exclude is None:
@@ -49,18 +42,7 @@ class StrawberryDataset(Dataset):
         if cube_size is None:
             cube_size = [200, 200]
 
-        if variant and variant in self.VARIANT_REPOS:
-            if not obtain:
-                obtain = {}
-            if "hf" not in obtain:
-                obtain["hf"] = {}
-            if "repo_id" not in obtain["hf"]:
-                obtain["hf"]["repo_id"] = self.VARIANT_REPOS[variant]
-            if "local_dir" not in obtain["hf"]:
-                obtain["hf"]["local_dir"] = f"data/{variant}_dataset"
-
         self.root_dir = Path(root_dir)
-        self.variant = variant
 
         if not self.root_dir.exists():
             if obtain and isinstance(obtain, dict) and "hf" in obtain:


### PR DESCRIPTION
# Switch to HyperspectralTiny Dataset for Faster Testing

## Summary
This PR changes the default Hugging Face dataset from `nghorbani/Hyperspektral-Small` to `nghorbani/HyperspectralTiny` in both EfficientAD and PerPixelAE configurations. This provides a smaller dataset for faster testing and development iteration.

**Changes made:**
- Updated `repo_id` and `local_dir` in all dataset configs to use HyperspectralTiny
- Updated `dataset_dir` paths to match the new dataset structure
- Removed variant system complexity as requested - users should manually change `repo_id` in YAML for different datasets

## Review & Testing Checklist for Human
- [ ] **Verify HyperspectralTiny dataset exists and is accessible** - The new dataset may have different structure or access permissions than Hyperspektral-Small
- [ ] **Test training pipeline end-to-end** - Run `uv run cuvisai-train model=efficientad/medium dataset=efficientad trainer.max_epochs=1` to ensure the new dataset loads and processes correctly
- [ ] **Validate dataset structure and paths** - Confirm that `./data/HyperspectralTiny/bedding_dataset` contains the expected files and folder structure
- [ ] **Check normalization parameters** - The hardcoded mean/std values may not be appropriate for the Tiny dataset - consider if they need updating based on the new dataset's characteristics

### Notes
- This change prioritizes simplicity over the previously implemented variant system
- Manual `repo_id` changes in YAML configs are now the intended way to switch between different dataset sizes
- The existing normalization parameters were kept unchanged - these may need adjustment if the Tiny dataset has different statistical properties than the Small dataset

**Requested by:** @nghorbani  
**Link to Devin run:** https://app.devin.ai/sessions/e0a052e52f004c2f8c3f358662bb2ea3